### PR TITLE
Fixed item links in top 20

### DIFF
--- a/lib/routes/zhubai/top20.ts
+++ b/lib/routes/zhubai/top20.ts
@@ -51,7 +51,7 @@ async function handler(ctx) {
 
     let items = response.data.slice(0, limit).map((item) => ({
         title: item.pn,
-        link: item.pq ?? item.pu ?? item.fp,
+        link: item.pu ?? item.pq ?? item.fp,
         description: item.pa,
         author: item.zn,
         pubDate: parseRelativeDate(item.lu.replace(/\.\d+/, '')),

--- a/lib/routes/zhubai/top20.ts
+++ b/lib/routes/zhubai/top20.ts
@@ -51,7 +51,7 @@ async function handler(ctx) {
 
     let items = response.data.slice(0, limit).map((item) => ({
         title: item.pn,
-        link: item.fp ?? item.pq ?? item.pu,
+        link: item.pq ?? item.pu ?? item.fp,
         description: item.pa,
         author: item.zn,
         pubDate: parseRelativeDate(item.lu.replace(/\.\d+/, '')),


### PR DESCRIPTION
Not sure whether the behavior is what you expected. 
I notice that the link provided in RSS is to an image, but not an original post.
After investigated the source code, I found that "fp" is the link to image.
Have no idea about the difference about "pu" and "pq". so I took a look at the rendered HTML, the link is from attribute "pu", which has a common URL "https://open.zhubai.wiki/a/l/t/z/pl/huazi" with path "pl".
My conclusion is maybe we should extract link from "pu" first, then "pq", and take "fp" as a fallback.
If you don't mind, could you contribute to upstream after accepting this change?